### PR TITLE
Mliukis issue89 restore db from snapshot

### DIFF
--- a/application_package/README.md
+++ b/application_package/README.md
@@ -45,6 +45,9 @@ export TF_VAR_api_id=value1
 export TF_VAR_api_parent_id=value2
 export TF_VAR_availability_zone=us-west-2b
 
+# Optional variable to set AWS ARN for the database snapshot to preserve database between the application deployments. If default empty string is used for the ARN, then empty database is created.
+export TF_VAR_db_snapshot=""
+
 # Do not worry about populating these tokens correctly for infrastructure/initial deploy (step #1 below), they will need to be set for the deployment of the Dockstore API in step #2:
 export TF_VAR_dockstore_token=""
 export TF_VAR_eni_private_ip=""
@@ -61,6 +64,8 @@ Where:
 Note: Both ID values are accessible through `AWS Console: API Gateway -> Unity API Gateway` where upper toolbar lists the ID values: `APIs > Unity API Gateway (value1) > Resources > /ads (value2)`
 
 `availability_zone` - the availability zone requested for the DB and other resources and should match available subnets availability zones.
+
+`db_snapshot` - optional AWS ARN of the manual database snapshot. Please be aware that automatically generated backup snapshots will be deleted when original database is destroyed. To preserve database between deployments user needs to create manual database snapshot through `AWS Console:  RDB -> Select awsdbdockstorestack-dbinstance* database -> "Maintenance & backups" tab -> "Take snapshot" under "Actions"`.
 
 `dockstore_token` - the Dockstore administrator account token that will be used for the GitHub Lambda authentication. The token is accessible from the Dockstore user account once the Dockstore application is deployed and administrator user is registered with the application. Please note that `dockstore_token` cannot be set until after the Dockstore application has been deployed in the `#2. Application Deployment` step (please see below).
 

--- a/application_package/README.md
+++ b/application_package/README.md
@@ -45,10 +45,13 @@ export TF_VAR_api_id=value1
 export TF_VAR_api_parent_id=value2
 export TF_VAR_availability_zone=us-west-2b
 
-# Optional variable to set AWS ARN for the database snapshot to preserve database between the application deployments. If default empty string is used for the ARN, then empty database is created.
+# Optional variable to set AWS ARN for the database manual snapshot to preserve
+# database between the application deployments.
+# If default empty string is used for the ARN, then newly created database will be empty.
 export TF_VAR_db_snapshot=""
 
-# Do not worry about populating these tokens correctly for infrastructure/initial deploy (step #1 below), they will need to be set for the deployment of the Dockstore API in step #2:
+# Do not worry about populating these tokens correctly for infrastructure/initial deploy (step #1 below),
+# they will need to be set for the deployment of the Dockstore API in step #2:
 export TF_VAR_dockstore_token=""
 export TF_VAR_eni_private_ip=""
 ```

--- a/application_package/dockstore/app_deploy/app/dockstore-app.tf
+++ b/application_package/dockstore/app_deploy/app/dockstore-app.tf
@@ -17,7 +17,7 @@ resource "aws_cloudformation_stack" "dockstore_app" {
     ComposeSetupVersion = "${var.compose_setup_version}"
     DockstoreDeployVersion = "${var.dockstore_deploy_version}"
     UiVersion = "${var.uiversion}"
-    GalaxyPluginVersion = "${var.galaxy_plugin_version}" 
+    GalaxyPluginVersion = "${var.galaxy_plugin_version}"
     ENIPrivateIP = "${var.eni_private_ip}"
 
     #These inputs are AWS Session Manager Parameter Store paths

--- a/application_package/dockstore/app_deploy/app/dockstore-app.yml
+++ b/application_package/dockstore/app_deploy/app/dockstore-app.yml
@@ -166,7 +166,7 @@ Parameters:
   LatestAMI:
     Description: The latest golden AMI to create EC2 with
     Type: 'AWS::SSM::Parameter::Value<AWS::EC2::Image::Id>'
-    Default: /mcp/amis/ubuntu2004
+    Default: /mcp/amis/ubuntu2004-cset
 
   #Unused params
   BdCatalystSevenBridgesImportUrl:
@@ -211,19 +211,19 @@ Parameters:
 
 
   #Used
-  #Here domain name is just URL - would be nice to eventually switch to domain names 
-  DomainName:     
+  #Here domain name is just URL - would be nice to eventually switch to domain names
+  DomainName:
     Description: The domain of this Dockstore instance, e.g., dockstore.org, staging.dockstore.org, .dockstore.net
     Type: AWS::SSM::Parameter::Value<String>
     Default: /DeploymentConfig/dev/DomainName
-  FeaturedContentUrl: 
+  FeaturedContentUrl:
     Description: The CloudFront content to populate the featured collection and organization
     Type: AWS::SSM::Parameter::Value<String>
     Default: /DeploymentConfig/dev/FeaturedContentURL
-  FeaturedNewsUrl: 
+  FeaturedNewsUrl:
     Description: The CloudFront content to populate news and events
     Type: AWS::SSM::Parameter::Value<String>
-    Default: /DeploymentConfig/dev/FeaturedNewsURL    
+    Default: /DeploymentConfig/dev/FeaturedNewsURL
   GitHubAppId:
     Description: The GitHub App id
     Type: AWS::SSM::Parameter::Value<String>
@@ -398,8 +398,8 @@ Resources:
   InstanceProfile:
     Type: "AWS::IAM::InstanceProfile"
     Properties:
-      Roles: 
-       - "DockstoreInstanceRole" 
+      Roles:
+       - "DockstoreInstanceRole"
 
   DockstoreEIP:
     Type: AWS::EC2::EIP
@@ -585,8 +585,8 @@ Resources:
               command: mkdir github-key
               cwd: "/home/ubuntu"
             "02_aws_cp":
-              command: 
-               !Join 
+              command:
+               !Join
                 - ""
                 - - "aws s3 cp s3://"
                   - Fn::ImportValue: !Sub "${S3Stack}-S3BucketName"
@@ -603,7 +603,7 @@ Resources:
               cwd: "/home/ubuntu/compose_setup/"
             "06_aws_cp_2":
               command:
-               !Join 
+               !Join
                 - ""
                 - - "aws s3 cp s3://"
                   - Fn::ImportValue: !Sub "${S3Stack}-S3BucketName"
@@ -629,7 +629,7 @@ Resources:
               command: bash ./sed_command.sh
               cwd: "/home/ubuntu/compose_setup/"
             "10_sed_2":
-              command: 
+              command:
                !Join
                - ""
                - - "sed -i 's/uads-test-dockstore-deploy-lb-1762603872.us-west-2.elb.amazonaws.com/"
@@ -643,7 +643,7 @@ Resources:
                command: sed -i 's/:443//g' config/web.yml
                cwd: "/home/ubuntu/compose_setup/"
             "13_sed_5":
-               command: 
+               command:
                  !Join
                   - ""
                   - - "sed -i 's/ gitHubRedirectPath: .*/ gitHubRedirectPath: http:\\/\\/"
@@ -661,7 +661,7 @@ Resources:
             "15_index_2":
                command:
                 !Join
-                - "" 
+                - ""
                 - - "curl -X PUT \""
                   - Fn::ImportValue: !Sub "${ElasticsearchStack}-ESDomainEndpoint"
                   - "/tools\" -H 'Content-Type: application/json' -d'{ \"settings\" : { \"index\" : {} }}'"
@@ -966,7 +966,7 @@ Resources:
           apt-get -qq -y install python3-pip
           apt install -y postgresql-client-common postgresql-client-12
           # Install cfn-bootstrap
-          wget --quiet https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-py3-2.0-6.tar.gz -O /root/aws-cfn-bootstrap.tar.gz 
+          wget --quiet https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-py3-2.0-6.tar.gz -O /root/aws-cfn-bootstrap.tar.gz
           tar xzf /root/aws-cfn-bootstrap.tar.gz -C /root
           pip3 install /root/aws-cfn-bootstrap.tar.gz
 
@@ -1052,7 +1052,7 @@ Resources:
       GroupId:
         Fn::ImportValue: !Sub '${RdsStack}-DBSecurityGroup'
       SourceSecurityGroupId: !Ref DockstoreServerSecurityGroup
- 
+
   #Modify the ES security group to add ingress rules allowing traffic from Dockstore instance SG
   DockstoreElasticsearchSecurityGroupIngress:
     Type: AWS::EC2::SecurityGroupIngress
@@ -1078,7 +1078,7 @@ Resources:
       Name: !Sub '${AWS::StackName}-80'
       Port: 80
       Protocol: HTTP
-      VpcId: !Ref VpcId 
+      VpcId: !Ref VpcId
       Targets:
         - Id: !Ref DockstoreInstance
           Port: 80
@@ -1096,7 +1096,7 @@ Resources:
       Name: !Sub '${AWS::StackName}-8080'
       Port: 8080
       Protocol: HTTP
-      VpcId: !Ref VpcId 
+      VpcId: !Ref VpcId
       Targets:
         - Id: !Ref DockstoreInstance
           Port: 8080
@@ -1105,7 +1105,7 @@ Resources:
   WebACLAssociation:
     Type: AWS::WAFv2::WebACLAssociation
     Properties:
-      ResourceArn:  
+      ResourceArn:
        Fn::ImportValue: !Sub "${LoadBalancerStack}-LoadBalancer"
       WebACLArn:
         Fn::ImportValue:
@@ -1120,12 +1120,12 @@ Resources:
       DefaultActions:
         - Type: forward
           TargetGroupArn: !Ref TargetGroupPort80
-      LoadBalancerArn: 
+      LoadBalancerArn:
        Fn::ImportValue: !Sub "${LoadBalancerStack}-LoadBalancer"
       Port: 9998
       Protocol: HTTP
       #SslPolicy: ELBSecurityPolicy-TLS-1-2-Ext-2018-06
- 
+
   #Listen on port 9999 and redirect to port 8080 on EC2
   LbPort9999Listener:
     Type: 'AWS::ElasticLoadBalancingV2::Listener'
@@ -1135,7 +1135,7 @@ Resources:
       DefaultActions:
         - Type: forward
           TargetGroupArn: !Ref TargetGroupPort8080
-      LoadBalancerArn: 
+      LoadBalancerArn:
        Fn::ImportValue: !Sub "${LoadBalancerStack}-LoadBalancer"
       Port: 9999
       Protocol: HTTP
@@ -1150,10 +1150,10 @@ Resources:
       DefaultActions:
         - Type: forward
           TargetGroupArn: !Ref TargetGroupPort80
-      LoadBalancerArn: 
+      LoadBalancerArn:
        Fn::ImportValue: !Sub "${LoadBalancerStack}-LoadBalancer"
       Port: 80
       Protocol: HTTP
       #SslPolicy: ELBSecurityPolicy-TLS-1-2-Ext-2018-06
- 
+
 

--- a/application_package/dockstore/app_deploy/app_vars.tf
+++ b/application_package/dockstore/app_deploy/app_vars.tf
@@ -30,5 +30,8 @@ variable "galaxy_plugin_version" {
   default     = "0.0.7"
 }
 
-
+variable "eni_private_ip" {
+  description = "Private IP to use for the ENI associated with EC2"
+  type = string
+}
 

--- a/application_package/dockstore/common/variables.tf
+++ b/application_package/dockstore/common/variables.tf
@@ -29,6 +29,12 @@ variable "availability_zone" {
 }
 
 variable "eni_private_ip" {
-  description = "Private IP to use for the ENI associated with EC2" 
+  description = "Private IP to use for the ENI associated with EC2"
   type = string
+}
+
+variable "db_snapshot" {
+  description = "AWS ARN of the RDB snapshot to restore new deployment of the database from"
+  type = string
+  default = ""
 }

--- a/application_package/dockstore/common/variables.tf
+++ b/application_package/dockstore/common/variables.tf
@@ -28,6 +28,17 @@ variable "availability_zone" {
   default = "us-west-2d"
 }
 
+variable "lb_logs_bucket_name" {
+  description = "The name of manually created S3 bucket to store Load Balancer logs"
+  type = string
+  default = "uads-dev-dockstore-elb-logs"
+}
+
+variable "lb_logs_bucket_prefix" {
+  description = "The prefix for the location in the S3 bucket for the Load Balancer access logs"
+  type = string
+  default = "AccessLogs"
+}
 
 variable "db_snapshot" {
   description = "AWS ARN of the RDB snapshot to restore new deployment of the database from"

--- a/application_package/dockstore/common/variables.tf
+++ b/application_package/dockstore/common/variables.tf
@@ -28,10 +28,6 @@ variable "availability_zone" {
   default = "us-west-2d"
 }
 
-variable "eni_private_ip" {
-  description = "Private IP to use for the ENI associated with EC2"
-  type = string
-}
 
 variable "db_snapshot" {
   description = "AWS ARN of the RDB snapshot to restore new deployment of the database from"

--- a/application_package/dockstore/initial_deploy/core/core.tf
+++ b/application_package/dockstore/initial_deploy/core/core.tf
@@ -18,7 +18,6 @@ resource "aws_cloudformation_stack" "core" {
 }
 
 
-
 resource "aws_api_gateway_deployment" "ApiRedeploy" {
   rest_api_id = "${var.api_id}"
   stage_name  = "${var.resource_prefix}"

--- a/application_package/dockstore/initial_deploy/database/database.tf
+++ b/application_package/dockstore/initial_deploy/database/database.tf
@@ -5,6 +5,7 @@ resource "aws_cloudformation_stack" "db" {
     ResourcePrefix = "${var.resource_prefix}"
     DBName = "${var.resource_prefix}"
     DBMasterUserPassword  = "/DeploymentConfig/${var.resource_prefix}/DBPostgresPassword"
+    DBSnapshot = "${var.db_snapshot}"
     VpcId = data.aws_vpc.unity_vpc.id
     SubnetId1 = tolist(data.aws_subnets.unity_public_subnets.ids)[0]
     SubnetId2 = tolist(data.aws_subnets.unity_public_subnets.ids)[1]
@@ -12,7 +13,7 @@ resource "aws_cloudformation_stack" "db" {
   }
 
   template_body = file("${path.module}/database.yml")
-  
+
   timeout_in_minutes = 60
 
 }

--- a/application_package/dockstore/initial_deploy/database/database.yml
+++ b/application_package/dockstore/initial_deploy/database/database.yml
@@ -142,13 +142,11 @@ Resources:
       BackupRetentionPeriod: !Ref DBBackupRetentionPeriod
       CopyTagsToSnapshot: true
       DBInstanceClass: !Ref DBInstanceClass
-      # DBName: !Ref DBName
       DBName:
         !If
         - UseDbSnapshot
         - !Ref AWS::NoValue
         - !Ref DBName
-      # DBSnapshotIdentifier: !Ref DBSnapshot
       DBSnapshotIdentifier:
         !If
         - UseDbSnapshot
@@ -158,7 +156,6 @@ Resources:
       EnableCloudwatchLogsExports:
         - postgresql
         - upgrade
-      # EnablePerformanceInsights: true
       EnablePerformanceInsights:
         !If
           - UseDbSnapshot
@@ -166,20 +163,17 @@ Resources:
           - true
       Engine: postgres
       EngineVersion: !Ref EngineVersion
-      # MasterUsername: postgres
       MasterUsername:
         !If
           - UseDbSnapshot
           - !Ref AWS::NoValue
           - postgres
-      # MasterUserPassword: !Ref DBMasterUserPassword
       MasterUserPassword:
         !If
           - UseDbSnapshot
           - !Ref AWS::NoValue
           - !Ref DBMasterUserPassword
       MultiAZ: !Ref DBMultiAZ
-      # StorageEncrypted: true
       StorageEncrypted:
         !If
           - UseDbSnapshot

--- a/application_package/dockstore/initial_deploy/database/database.yml
+++ b/application_package/dockstore/initial_deploy/database/database.yml
@@ -44,6 +44,10 @@ Parameters:
     Description: 'Name of the database (ignored when DBSnapshotIdentifier is set, value used from snapshot).'
     Type: String
     Default: dev
+  DBSnapshot:
+    Description: 'AWS ARN of the RDB snapshot to restore new deployment of the database from. Create empty DB if not provided.'
+    Type: String
+    Default: ''
   DBBackupRetentionPeriod:
     Description: 'The number of days to keep snapshots of the database.'
     Type: Number
@@ -94,6 +98,7 @@ Metadata:
           - DBName
           - DBBackupRetentionPeriod
           - DBMasterUserPassword
+          - DBSnapshot
           - DBMultiAZ
           - PreferredBackupWindow
           - PreferredMaintenanceWindow
@@ -129,8 +134,9 @@ Resources:
       CopyTagsToSnapshot: true
       DBInstanceClass: !Ref DBInstanceClass
       DBName: !Ref DBName
+      DBSnapshotIdentifier: !Ref DBSnapshot
       DBSubnetGroupName: !Ref DBSubnetGroup
-      EnableCloudwatchLogsExports: 
+      EnableCloudwatchLogsExports:
         - postgresql
         - upgrade
       EnablePerformanceInsights: true

--- a/application_package/dockstore/initial_deploy/database/database.yml
+++ b/application_package/dockstore/initial_deploy/database/database.yml
@@ -105,6 +105,15 @@ Metadata:
           - EngineVersion
           - EnableIAMDatabaseAuthentication
 
+# If using DB snapshot to restore DB from, then can't use DBName to create
+# AWS::RDS::DBInstance
+Conditions:
+  UseDbSnapshot:
+    !Not
+      - !Equals
+        - !Ref DBSnapshot
+        - ''
+
 Resources:
 
   DBSubnetGroup:
@@ -133,19 +142,49 @@ Resources:
       BackupRetentionPeriod: !Ref DBBackupRetentionPeriod
       CopyTagsToSnapshot: true
       DBInstanceClass: !Ref DBInstanceClass
-      DBName: !Ref DBName
-      DBSnapshotIdentifier: !Ref DBSnapshot
+      # DBName: !Ref DBName
+      DBName:
+        !If
+        - UseDbSnapshot
+        - !Ref AWS::NoValue
+        - !Ref DBName
+      # DBSnapshotIdentifier: !Ref DBSnapshot
+      DBSnapshotIdentifier:
+        !If
+        - UseDbSnapshot
+        - !Ref DBSnapshot
+        - !Ref AWS::NoValue
       DBSubnetGroupName: !Ref DBSubnetGroup
       EnableCloudwatchLogsExports:
         - postgresql
         - upgrade
-      EnablePerformanceInsights: true
+      # EnablePerformanceInsights: true
+      EnablePerformanceInsights:
+        !If
+          - UseDbSnapshot
+          - !Ref AWS::NoValue
+          - true
       Engine: postgres
       EngineVersion: !Ref EngineVersion
-      MasterUsername: postgres
-      MasterUserPassword: !Ref DBMasterUserPassword
+      # MasterUsername: postgres
+      MasterUsername:
+        !If
+          - UseDbSnapshot
+          - !Ref AWS::NoValue
+          - postgres
+      # MasterUserPassword: !Ref DBMasterUserPassword
+      MasterUserPassword:
+        !If
+          - UseDbSnapshot
+          - !Ref AWS::NoValue
+          - !Ref DBMasterUserPassword
       MultiAZ: !Ref DBMultiAZ
-      StorageEncrypted: true
+      # StorageEncrypted: true
+      StorageEncrypted:
+        !If
+          - UseDbSnapshot
+          - !Ref AWS::NoValue
+          - true
       StorageType: gp2
       VPCSecurityGroups:
       - !Ref DBSecurityGroup

--- a/application_package/dockstore/initial_deploy/iam/iam.yml
+++ b/application_package/dockstore/initial_deploy/iam/iam.yml
@@ -9,7 +9,7 @@ Parameters:
     MaxLength: 128
     Default: dev
 
-Resources: 
+Resources:
   EnvironmentTagSsmAccessPolicy:
     Type: AWS::IAM::ManagedPolicy
     Properties:
@@ -49,18 +49,18 @@ Resources:
         AssumeRolePolicyDocument:
           Version: "2012-10-17"
           Statement:
-             Effect: Allow 
+             Effect: Allow
              Action:
-               - "sts:AssumeRole"  
+               - "sts:AssumeRole"
              Principal:
                  Service:
                   -  cloudformation.amazonaws.com
-        PermissionsBoundary: !Sub "arn:aws:iam::${AWS::AccountId}:policy/mcp-tenantOperator-AMI-APIG"      
+        PermissionsBoundary: !Sub "arn:aws:iam::${AWS::AccountId}:policy/mcp-tenantOperator-AMI-APIG"
         ManagedPolicyArns:
               - "arn:aws:iam::aws:policy/IAMFullAccess"
               - "arn:aws:iam::aws:policy/AmazonS3FullAccess"
               - "arn:aws:iam::aws:policy/AWSCloudFormationFullAccess"
- 
+
 
   ModifyInstanceMetaDataOptionsRole:
     Type: AWS::IAM::Role
@@ -107,10 +107,16 @@ Resources:
             # gave "s3:*" permissions. That's how the deployer was able to deploy lambdas before.
             # These buckets are in different accounts, but it's easier and still safe to just list all lambda buckets
             Resource:
-              - !Sub 'arn:aws:s3:::uads-${ResourcePrefix}-dockstore.lambda'
-              - !Sub 'arn:aws:s3:::uads-${ResourcePrefix}-dockstore.lambda/*'
-              - !Sub 'arn:aws:s3:::uads-${ResourcePrefix}-dockstore-deploy/*'
-              - !Sub 'arn:aws:s3:::uads-${ResourcePrefix}-dockstore-deploy'
+              # - !Sub 'arn:aws:s3:::uads-${ResourcePrefix}-dockstore.lambda'
+              # - !Sub 'arn:aws:s3:::uads-${ResourcePrefix}-dockstore.lambda/*'
+              # - !Sub 'arn:aws:s3:::uads-${ResourcePrefix}-dockstore-deploy/*'
+              # - !Sub 'arn:aws:s3:::uads-${ResourcePrefix}-dockstore-deploy'
+              - !Sub 'arn:aws:s3:::uads-${ResourcePrefix}-dockstore-lambda-bucket'
+              - !Sub 'arn:aws:s3:::uads-${ResourcePrefix}-dockstore-lambda-bucket/*'
+              - !Sub 'arn:aws:s3:::uads-${ResourcePrefix}-dockstore-startup/*'
+              - !Sub 'arn:aws:s3:::uads-${ResourcePrefix}-dockstore-startup'
+              # - !Sub 'arn:aws:s3:::uads-${ResourcePrefix}-dockstore-startup/*'
+              # - !Sub 'arn:aws:s3:::uads-${ResourcePrefix}-dockstore-startup'
           - Effect: Allow
             Action:
                 - 'sqs:CreateQueue'
@@ -126,7 +132,7 @@ Resources:
             Action:
               - 's3:PutObject'
               - 's3:GetObject'
-              - 's3:ListObject'
+              - 's3:ListObjects'
             Resource:
                 - 'arn:aws:s3:::cdktoolkit-stagingbucket-*/*'
                 - 'arn:aws:s3:::cdktoolkit-stagingbucket-*'

--- a/application_package/dockstore/initial_deploy/load_balancer/load_balancer.tf
+++ b/application_package/dockstore/initial_deploy/load_balancer/load_balancer.tf
@@ -7,8 +7,9 @@ resource "aws_cloudformation_stack" "dev" {
     SubnetId1 = tolist(data.aws_subnets.unity_public_subnets.ids)[0]
     SubnetId2 = tolist(data.aws_subnets.unity_public_subnets.ids)[1]
     S3Stack = "awsS3DockstoreStack"
+    LBLogsS3BucketName = "${var.lb_logs_bucket_name}"
+    LBLogsS3BucketPrefix = "${var.lb_logs_bucket_prefix}"
   }
-
 
   template_body = file("${path.module}/load_balancer.yml")
 

--- a/application_package/dockstore/initial_deploy/load_balancer/load_balancer.yml
+++ b/application_package/dockstore/initial_deploy/load_balancer/load_balancer.yml
@@ -12,7 +12,7 @@ Parameters:
     Description: Env prefix (dev or test)
     Type: String
     Default: 'dev'
-  VpcId: 
+  VpcId:
     Description: ID for the VPC the LB is to be within
     Type: String
   SubnetId1:
@@ -20,6 +20,12 @@ Parameters:
     Type: String
   SubnetId2:
     Description: ID for the second subnet the LB is to be accessible on
+    Type: String
+  LBLogsS3BucketName:
+    Description: The name of the S3 bucket for the LB logs
+    Type: String
+  LBLogsS3BucketPrefix:
+    Description: The prefix for the location in the S3 bucket for the LB access logs
     Type: String
   LoadBalancerIdleTimeout:
     Description: The idle timeout value, in seconds
@@ -94,9 +100,9 @@ Resources:
         - Key: "access_logs.s3.enabled"
           Value: 'true'
         - Key: "access_logs.s3.bucket"
-          Value:
-            Fn::ImportValue:
-              !Sub '${S3Stack}-ElbLogsBucket'
+          Value: !Sub '${LBLogsS3BucketName}'
+        - Key: "access_logs.s3.prefix"
+          Value: !Sub '${LBLogsS3BucketPrefix}'
         - Key: "deletion_protection.enabled"
           Value: 'false'
       Name: !Sub '${AWS::StackName}-lb'
@@ -104,8 +110,8 @@ Resources:
       SecurityGroups:
         - !Ref LbSecurityGroup
       Subnets:
-         - !Ref SubnetId1 
-         - !Ref SubnetId2 
+         - !Ref SubnetId1
+         - !Ref SubnetId2
       Type: application
       Tags:
         - Key: Name

--- a/application_package/dockstore/initial_deploy/main.tf
+++ b/application_package/dockstore/initial_deploy/main.tf
@@ -38,6 +38,8 @@ module "load_balancer" {
     resource_prefix = "${var.resource_prefix}"
     api_id = "${var.api_id}"
     api_parent_id = "${var.api_parent_id}"
+    lb_logs_bucket_name = "${var.lb_logs_bucket_name}"
+    lb_logs_bucket_prefix = "${var.lb_logs_bucket_prefix}"
 
     depends_on = [
         module.s3
@@ -63,6 +65,7 @@ module "database" {
     resource_prefix = "${var.resource_prefix}"
     api_id = "${var.api_id}"
     api_parent_id = "${var.api_parent_id}"
+    db_snapshot = "${var.db_snapshot}"
 
     depends_on = [
         module.core
@@ -87,7 +90,7 @@ module "elasticsearch" {
     resource_prefix = "${var.resource_prefix}"
     api_id = "${var.api_id}"
     api_parent_id = "${var.api_parent_id}"
-    
+
     depends_on = [
         module.es-log-groups
     ]

--- a/application_package/dockstore/initial_deploy/s3/s3.tf
+++ b/application_package/dockstore/initial_deploy/s3/s3.tf
@@ -1,21 +1,19 @@
+locals {
+  startup_bucket_name = "uads-${var.resource_prefix}-dockstore-startup"
+}
+
 resource "aws_cloudformation_stack" "s3" {
   name = "awsS3DockstoreStack"
 
-
   parameters = {
     ResourcePrefix = "${var.resource_prefix}"
-    ELBLogsBucketName = "uads-${var.resource_prefix}-dockstore-elb-logs"
-    BucketName = "uads-${var.resource_prefix}-dockstore-startup"
+    BucketName = "${local.startup_bucket_name}"
   }
-
 
   template_body = file("${path.module}/s3.yml")
   #iam_role_arn = "arn:aws:iam::237868187491:role/uads-dockstore-cf-role"
   capabilities = ["CAPABILITY_NAMED_IAM", "CAPABILITY_IAM"]
-
 }
-
-
 
 
 resource "aws_s3_bucket" "lambda_bucket" {
@@ -118,13 +116,10 @@ resource "aws_s3_object" "sed_script" {
   source = "${path.module}/sed_command.sh"
 
   etag = filemd5("${path.module}/sed_command.sh")
- 
+
   depends_on = [
     aws_cloudformation_stack.s3
   ]
 }
-
-
-
 
 

--- a/application_package/dockstore/initial_deploy/s3/s3.yml
+++ b/application_package/dockstore/initial_deploy/s3/s3.yml
@@ -61,11 +61,6 @@ Resources:
     Properties:
       BucketName: !Ref BucketName
       AccessControl: Private
-      # PublicAccessBlockConfiguration:
-      #   BlockPublicAcls: false
-      #   BlockPublicPolicy: false
-      #   IgnorePublicAcls: false
-      #   RestrictPublicBuckets: false
       BucketEncryption:
         ServerSideEncryptionConfiguration:
           - ServerSideEncryptionByDefault:

--- a/application_package/dockstore/initial_deploy/s3/s3.yml
+++ b/application_package/dockstore/initial_deploy/s3/s3.yml
@@ -26,11 +26,6 @@ Parameters:
     Type: String
     MinLength: 1
     Default: uads-dev-dockstore-startup
-  ELBLogsBucketName:
-    Description: The bucket name for ELB Logs
-    Type: String
-    MinLength: 1
-    Default: uads-dev-dockstore-elb-logs
   ResourcePrefix:
     Description: The resource prefix (dev or test)
     Type: String
@@ -46,7 +41,7 @@ Mappings:
       ELBAccountId: 'arn:aws:iam::797873946194:root'
     us-east-2:
       ELBAccountId: 'arn:aws:iam::033677994240:root'
- 
+
 Resources:
   StartupBucketManagedPolicy:
     Type: AWS::IAM::ManagedPolicy
@@ -60,19 +55,17 @@ Resources:
           Effect: Allow
           Resource: !Join ['', [!GetAtt S3Bucket.Arn, '/*']]
 
-
-
   S3Bucket:
     Type: AWS::S3::Bucket
     DeletionPolicy: Delete
     Properties:
       BucketName: !Ref BucketName
       AccessControl: Private
-      PublicAccessBlockConfiguration:
-        BlockPublicAcls: false
-        BlockPublicPolicy: false
-        IgnorePublicAcls: false
-        RestrictPublicBuckets: false
+      # PublicAccessBlockConfiguration:
+      #   BlockPublicAcls: false
+      #   BlockPublicPolicy: false
+      #   IgnorePublicAcls: false
+      #   RestrictPublicBuckets: false
       BucketEncryption:
         ServerSideEncryptionConfiguration:
           - ServerSideEncryptionByDefault:
@@ -83,26 +76,6 @@ Resources:
         - Key: Environment
           Value: !Sub '${ResourcePrefix}'
 
-  ElbLogsBucket:
-    Type: AWS::S3::Bucket
-    DeletionPolicy: Delete
-    Properties:
-      BucketName: !Ref ELBLogsBucketName
-      AccessControl: PublicReadWrite
-      PublicAccessBlockConfiguration:
-        BlockPublicAcls: false
-        BlockPublicPolicy: false
-        IgnorePublicAcls: false
-        RestrictPublicBuckets: false
-      BucketEncryption:
-        ServerSideEncryptionConfiguration:
-          - ServerSideEncryptionByDefault:
-              SSEAlgorithm: AES256
-      Tags:
-        - Key: Name
-          Value: !Sub '${AWS::StackName}-elb-logs-bucket'
-        - Key: Environment
-          Value: !Sub '${ResourcePrefix}'
 
 Outputs:
   S3BucketName:
@@ -111,13 +84,8 @@ Outputs:
     Export:
       Name: !Sub '${AWS::StackName}-S3BucketName'
   StartupBucketManagedPolicy:
-    Description: Role to get get S3 items
+    Description: Role to get S3 items
     Value: !Ref StartupBucketManagedPolicy
     Export:
       Name: !Sub '${AWS::StackName}-StartupBucketManagedPolicy'
-  ElbLogsBucketName:
-    Description: The name of the S3 bucket that was created
-    Value: !Ref 'ElbLogsBucket'
-    Export:
-      Name: !Sub '${AWS::StackName}-ElbLogsBucket'
 


### PR DESCRIPTION
Fixes to address:
* Issue #89: Verify Dockstore database can be restored after rebuild
* Use pre-built S3 bucket for LB logs, which must have S3 bucket policy (created by MCP) attached to it to allow for the automatically deployed LB to write logs to it (we are not allowed to create S3 bucket policies)
* Fixed S3 bucket names and action for IAM module
* Use CSET-based AMI for EC2 hosting the Dockstore App