### PR TITLE
updates for deployment via Unity Marketplace

### DIFF
--- a/common/aws.tf
+++ b/common/aws.tf
@@ -2,7 +2,7 @@ locals {
   cost_tags = {
     ServiceArea = "аds"
     Proj = "${var.project}"
-    Venue = "${var.venue_prefix}${var.venue}"
+    Venue = "${var.deployment_name}-${var.venue}"
     Component = "${var.component_cost_name}"
     CreatedBy = "ads"
     Env = "${var.resource_prefix}"

--- a/common/variables.tf
+++ b/common/variables.tf
@@ -9,7 +9,7 @@ variable "venue" {
   type        = string
 }
 
-variable "venue_prefix" {
+variable "deployment_name" {
   description = "Optional string to place before the venue name in resource names"
   type        = string
   default     = ""

--- a/dev_env/cognito/cognito_client.tf
+++ b/dev_env/cognito/cognito_client.tf
@@ -3,7 +3,7 @@ data "aws_cognito_user_pools" "unity_user_pool" {
 }
 
 resource "aws_cognito_user_pool_client" "jupyter_cognito_client" {
-  name          = "${var.resource_prefix}-jupyter-${var.venue_prefix}${var.venue}-client"
+  name          = "${var.resource_prefix}-jupyter-${var.deployment_name}-${var.venue}-client"
   user_pool_id  = tolist(data.aws_cognito_user_pools.unity_user_pool.ids)[0]
 
   callback_urls = var.jupyter_base_url != null ? ["${var.jupyter_base_url}/${var.jupyter_base_path}/hub/oauth_callback"] : null

--- a/dev_env/jupyterhub/aws.tf
+++ b/dev_env/jupyterhub/aws.tf
@@ -9,3 +9,9 @@ locals {
     Stack = "${var.component_cost_name}"
   }
 }
+
+provider "aws" {
+  default_tags {
+    tags = local.cost_tags
+  }
+}

--- a/dev_env/jupyterhub/aws.tf
+++ b/dev_env/jupyterhub/aws.tf
@@ -1,1 +1,17 @@
-../../common/aws.tf
+locals {
+  cost_tags = {
+    ServiceArea = "аds"
+    Proj = "${var.project}"
+    Venue = "${var.deployment_name}-${var.venue}"
+    Component = "${var.component_cost_name}"
+    CreatedBy = "ads"
+    Env = "${var.resource_prefix}"
+    Stack = "${var.component_cost_name}"
+  }
+}
+
+provider "aws" {
+  default_tags {
+    tags = local.cost_tags
+  }
+}

--- a/dev_env/jupyterhub/aws.tf
+++ b/dev_env/jupyterhub/aws.tf
@@ -9,9 +9,3 @@ locals {
     Stack = "${var.component_cost_name}"
   }
 }
-
-provider "aws" {
-  default_tags {
-    tags = local.cost_tags
-  }
-}

--- a/dev_env/jupyterhub/common_variables.tf
+++ b/dev_env/jupyterhub/common_variables.tf
@@ -1,1 +1,28 @@
-../../common/variables.tf
+variable "project" {
+  description = "The name of the project matching the /unity/<{project>/<venue</project-name SSM parameter"
+  type        = string
+  default     = "unity"
+}
+
+variable "venue" {
+  description = "The name of the unity venue matching the /unity/<project>/<venue>/venue-name SSM parameter"
+  type        = string
+}
+
+variable "deployment_name" {
+  description = "Optional string to place before the venue name in resource names"
+  type        = string
+  default     = ""
+}
+
+variable "resource_prefix" {
+  description = "String used at the beginning of the names for all resources to identify them according to the UADS subsystem"
+  type        = string
+  default     = "uads"
+}
+
+variable "efs_identifier" {
+  description = "EFS file system to connect Jupyter shared storage with"
+  type        = string
+  # Example value:uads-development-efs-fs"
+}

--- a/dev_env/jupyterhub/common_variables.tf
+++ b/dev_env/jupyterhub/common_variables.tf
@@ -26,3 +26,13 @@ variable "efs_identifier" {
   type        = string
   # Example value:uads-development-efs-fs"
 }
+
+variable "installprefix" {
+  description = "Installation prefix"
+  type        = string
+  default     = ""
+}
+
+variable "tags" {
+  type = map(string)
+}

--- a/dev_env/jupyterhub/csi_driver.tf
+++ b/dev_env/jupyterhub/csi_driver.tf
@@ -23,6 +23,11 @@ module "ebs_csi_irsa_role" {
     "eks_addon" = "ebs-csi"
     "terraform" = "true"
   }
+
+  depends_on = [
+    module.eks,
+    null_resource.eks_post_deployment_actions
+  ]
 }
 
 resource "aws_eks_addon" "ebs-csi" {
@@ -36,7 +41,11 @@ resource "aws_eks_addon" "ebs-csi" {
     "terraform" = "true"
   }
 
-  depends_on = [ module.eks ]
+  depends_on = [
+    module.eks,
+    module.ebs_csi_irsa_role,
+    null_resource.eks_post_deployment_actions
+  ]
 }
 
 ################
@@ -65,6 +74,11 @@ module "efs_csi_irsa_role" {
     "eks_addon" = "efs-csi"
     "terraform" = "true"
   }
+
+  depends_on = [
+    module.eks,
+    null_resource.eks_post_deployment_actions
+  ]
 }
 
 resource "aws_eks_addon" "efs-csi" {
@@ -76,5 +90,9 @@ resource "aws_eks_addon" "efs-csi" {
     "terraform" = "true"
   }
 
-  depends_on = [ module.eks ]
+  depends_on = [
+    module.eks,
+    module.efs_csi_irsa_role,
+    null_resource.eks_post_deployment_actions
+  ]
 }

--- a/dev_env/jupyterhub/devenv_variables.tf
+++ b/dev_env/jupyterhub/devenv_variables.tf
@@ -1,1 +1,0 @@
-../common/variables.tf

--- a/dev_env/jupyterhub/ebs.tf
+++ b/dev_env/jupyterhub/ebs.tf
@@ -14,4 +14,8 @@ resource "kubernetes_storage_class" "ebs_storage_class" {
     # How to add custom tags to ebs-csi deployed volumes
     # https://github.com/kubernetes-sigs/aws-ebs-csi-driver/blob/master/docs/tagging.md
     { for i, k in keys(local.cost_tags) : "tagSpecification_${i}" => "${k}=${local.cost_tags[k]}" })
+
+  depends_on = [
+    aws_eks_addon.ebs-csi
+  ]
 }

--- a/dev_env/jupyterhub/efs.tf
+++ b/dev_env/jupyterhub/efs.tf
@@ -78,7 +78,8 @@ resource "kubernetes_persistent_volume" "dev_support_shared_volume" {
     kubernetes_storage_class.efs_storage_class,
     aws_efs_mount_target.dev_support_efs_mt_1,
     aws_efs_mount_target.dev_support_efs_mt_2,
-    aws_eks_addon.efs-csi
+    aws_eks_addon.efs-csi,
+    module.efs_csi_irsa_role
   ]
 }
 
@@ -105,6 +106,7 @@ resource "kubernetes_persistent_volume_claim" "dev_support_shared_volume_claim" 
   # Prevents a cycle with eks_cluster.jupyter_hub
   depends_on = [ 
     kubernetes_persistent_volume.dev_support_shared_volume,
-    aws_eks_addon.efs-csi
+    aws_eks_addon.efs-csi,
+    module.efs_csi_irsa_role
   ]
 }

--- a/dev_env/jupyterhub/efs.tf
+++ b/dev_env/jupyterhub/efs.tf
@@ -42,6 +42,10 @@ resource "kubernetes_storage_class" "efs_storage_class" {
 
   parameters = {
   }
+
+  depends_on = [
+    aws_eks_addon.efs-csi
+  ]
 }
 
 # Documentation on how to set up volume_handle:

--- a/dev_env/jupyterhub/efs.tf
+++ b/dev_env/jupyterhub/efs.tf
@@ -1,5 +1,5 @@
 resource "aws_security_group" "dev_support_efs_jupyter_sg" {
-   name = "${var.resource_prefix}-${var.venue_prefix}${var.venue}-efs-jupyter-sg"
+   name = "${var.resource_prefix}-${var.deployment_name}-${var.venue}-efs-jupyter-sg"
    description= "Allows inbound EFS traffic from Jupyter cluster"
    vpc_id = data.aws_ssm_parameter.vpc_id.value
 
@@ -50,7 +50,7 @@ resource "kubernetes_storage_class" "efs_storage_class" {
 # https://kubernetes.io/docs/concepts/storage/persistent-volumes/
 resource "kubernetes_persistent_volume" "dev_support_shared_volume" {
   metadata {
-    name = "${var.resource_prefix}-${var.venue_prefix}${var.venue}-dev-data"
+    name = "${var.resource_prefix}-${var.deployment_name}-${var.venue}-dev-data"
   }
 
   spec {
@@ -84,7 +84,7 @@ resource "kubernetes_persistent_volume" "dev_support_shared_volume" {
 
 resource "kubernetes_persistent_volume_claim" "dev_support_shared_volume_claim" {
   metadata {
-    name = "${var.resource_prefix}-${var.venue_prefix}${var.venue}-dev-data"
+    name = "${var.resource_prefix}-${var.deployment_name}-${var.venue}-dev-data"
     namespace = helm_release.jupyter_helm.namespace
   }
 

--- a/dev_env/jupyterhub/efs.tf
+++ b/dev_env/jupyterhub/efs.tf
@@ -38,7 +38,7 @@ resource "kubernetes_storage_class" "efs_storage_class" {
     name = "efs"
   }
   storage_provisioner = "efs.csi.aws.com"
-  reclaim_policy      = "Delete"
+  reclaim_policy      = "Retain"
 
   parameters = {
   }
@@ -61,7 +61,7 @@ resource "kubernetes_persistent_volume" "dev_support_shared_volume" {
       storage = "100Gi"
     }
 
-    persistent_volume_reclaim_policy = "Delete"
+    persistent_volume_reclaim_policy = "Retain"
 
     persistent_volume_source {
       csi {
@@ -70,7 +70,7 @@ resource "kubernetes_persistent_volume" "dev_support_shared_volume" {
       }
     }
 
-    mount_options = [ "iam" ]
+    mount_options = [ "tls", "iam" ]
   }
 
   # Prevents a cycle with eks_cluster.jupyter_hub

--- a/dev_env/jupyterhub/eks_cluster.tf
+++ b/dev_env/jupyterhub/eks_cluster.tf
@@ -13,13 +13,13 @@ data "external" "current_ip" {
 }
 
 resource "aws_security_group" "mc_instance_k8s_api_access" {
-  name        = "${var.resource_prefix}-${var.venue_prefix}${var.venue}-mc-sg"
+  name        = "${var.resource_prefix}-${var.deployment_name}-${var.venue}-mc-sg"
   description = "Security group to allow access to K8s API from MC instance"
 
   vpc_id = data.aws_ssm_parameter.vpc_id.value
 
   tags = {
-    Name = "${var.resource_prefix}-${var.venue_prefix}${var.venue}-mc-sg"
+    Name = "${var.resource_prefix}-${var.deployment_name}-${var.venue}-mc-sg"
   }
 
   # Allow all outbound traffic.
@@ -44,7 +44,7 @@ module "eks" {
   source  = "terraform-aws-modules/eks/aws"
   version = "~> 20.0"
 
-  cluster_name    = "${var.resource_prefix}-${var.venue_prefix}${var.venue}-jupyter"
+  cluster_name    = "${var.resource_prefix}-${var.deployment_name}-${var.venue}-jupyter"
   cluster_version = "1.30"
 
   cluster_addons = {
@@ -66,7 +66,7 @@ module "eks" {
   enable_irsa = true
 
   create_iam_role = true
-  iam_role_name = "Unity-ADS-${var.venue_prefix}${var.venue}-EKSClusterRole"
+  iam_role_name = "Unity-ADS-${var.deployment_name}-${var.venue}-EKSClusterRole"
   iam_role_permissions_boundary = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:policy/mcp-tenantOperator-AMI-APIG"
 
   cluster_endpoint_public_access = true
@@ -78,7 +78,7 @@ module "eks" {
 
   eks_managed_node_group_defaults = {
     create_iam_role = true
-    iam_role_name = "Unity-ADS-${var.venue_prefix}${var.venue}-EKSNodeRole"
+    iam_role_name = "Unity-ADS-${var.deployment_name}-${var.venue}-EKSNodeRole"
     iam_role_permissions_boundary = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:policy/mcp-tenantOperator-AMI-APIG"
 
     ami_id          = data.aws_ssm_parameter.ami_id.value

--- a/dev_env/jupyterhub/eks_cluster.tf
+++ b/dev_env/jupyterhub/eks_cluster.tf
@@ -109,7 +109,7 @@ module "eks" {
 resource "null_resource" "eks_post_deployment_actions" {
   depends_on = [module.eks]
   provisioner "local-exec" {
-    command = "./eks_post_deployment_actions.sh ${data.aws_region.current.name} ${module.eks.cluster_name}"
+    command = "${path.module}/eks_post_deployment_actions.sh ${data.aws_region.current.name} ${module.eks.cluster_name}"
   }
 }
 

--- a/dev_env/jupyterhub/eks_cluster.tf
+++ b/dev_env/jupyterhub/eks_cluster.tf
@@ -42,7 +42,8 @@ resource "aws_security_group" "mc_instance_k8s_api_access" {
 
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "~> 20.0"
+  # pin to 20.16.0 because unity-proxy is pinned to hashicorp/aws 5.47.0
+  version = "20.16.0"
 
   cluster_name    = "${var.resource_prefix}-${var.deployment_name}-${var.venue}-jupyter"
   cluster_version = "1.30"

--- a/dev_env/jupyterhub/eks_cluster.tf
+++ b/dev_env/jupyterhub/eks_cluster.tf
@@ -101,6 +101,19 @@ module "eks" {
       min_size       = var.eks_node_min_size
       max_size       = var.eks_node_max_size
       desired_size   = var.eks_node_desired_size
+      block_device_mappings = {
+        xvda = {
+          device_name = "/dev/xvda"
+          ebs = {
+            volume_size           = 75
+            volume_type           = "gp3"
+            iops                  = 3000
+            throughput            = 150
+            encrypted             = true
+            delete_on_termination = true
+          }
+        }
+      }
     }
   }
 

--- a/dev_env/jupyterhub/eks_cluster.tf
+++ b/dev_env/jupyterhub/eks_cluster.tf
@@ -9,7 +9,7 @@ data "aws_ssm_parameter" "ami_id" {
 }
 
 data "external" "current_ip" {
-  program = ["./get_ip.sh"]
+  program = ["${path.module}/get_ip.sh"]
 }
 
 resource "aws_security_group" "mc_instance_k8s_api_access" {

--- a/dev_env/jupyterhub/eks_pre_destroy_actions.sh
+++ b/dev_env/jupyterhub/eks_pre_destroy_actions.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -e
+
+# remove finalizers from EFS PVCs
+kubectl get pvc --all-namespaces --no-headers | grep ' efs ' | while read line; do
+  namespace=$(echo $line | awk '{print $1}')
+  pvc_name=$(echo $line | awk '{print $2}')
+  kubectl patch pvc ${pvc_name} -p '{"metadata":{"finalizers":null}}' -n ${namespace}
+done

--- a/dev_env/jupyterhub/frontend.tf
+++ b/dev_env/jupyterhub/frontend.tf
@@ -36,7 +36,7 @@ module "frontend" {
 
   project = var.project
   venue = var.venue
-  venue_prefix = var.venue_prefix
+  deployment_name = var.deployment_name
   resource_prefix = var.resource_prefix
   load_balancer_port = local.load_balancer_port
   jupyter_proxy_port = var.jupyter_proxy_port

--- a/dev_env/jupyterhub/get_ip.sh
+++ b/dev_env/jupyterhub/get_ip.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
-set -e
-IP=$(curl -s 'http://169.254.169.254/latest/meta-data/local-ipv4')
-jq -n --arg ip "$IP" '{"ip":$ip}'
+IP=$(curl --connect-timeout 1 -s 'http://169.254.169.254/latest/meta-data/local-ipv4')
+if [ "$IP" = "" ]; then
+  IP=127.0.0.1
+fi
+echo "{\"ip\": \"${IP}\"}"

--- a/dev_env/jupyterhub/health_check.tf
+++ b/dev_env/jupyterhub/health_check.tf
@@ -7,4 +7,9 @@ resource "aws_ssm_parameter" "jupyter_health_url" {
     landingPageUrl = "${module.frontend.jupyter_base_url}/${module.frontend.jupyter_base_path}/"
     componentName  = "Jupyterhub"
   })
+
+  provisioner "local-exec" {
+    when = destroy
+    command = "${path.module}/eks_pre_destroy_actions.sh"
+  }
 }

--- a/dev_env/jupyterhub/jupyter_helm.tf
+++ b/dev_env/jupyterhub/jupyter_helm.tf
@@ -2,7 +2,7 @@ resource "helm_release" "jupyter_helm" {
   name       = "jupyterhub"
   repository = "https://jupyterhub.github.io/helm-chart"
   chart      = "jupyterhub"
-  namespace  = "jhub-${var.venue_prefix}${var.venue}"
+  namespace  = "jhub-${var.deployment_name}-${var.venue}"
   version    = "3.1.0"
   timeout    = 3600
 

--- a/dev_env/jupyterhub/jupyter_helm.tf
+++ b/dev_env/jupyterhub/jupyter_helm.tf
@@ -36,7 +36,6 @@ resource "helm_release" "jupyter_helm" {
     module.efs_csi_irsa_role,
     module.ebs_csi_irsa_role,
     kubernetes_persistent_volume.dev_support_shared_volume,
-    kubernetes_persistent_volume_claim.dev_support_shared_volume_claim,
     null_resource.eks_post_deployment_actions
   ]
 }

--- a/dev_env/jupyterhub/jupyter_helm.tf
+++ b/dev_env/jupyterhub/jupyter_helm.tf
@@ -29,7 +29,13 @@ resource "helm_release" "jupyter_helm" {
   depends_on = [
     module.frontend,
     module.eks,
-    null_resource.eks_post_deployment_actions,
+    kubernetes_storage_class.efs_storage_class,
+    kubernetes_storage_class.ebs_storage_class,
+    aws_eks_addon.efs-csi,
+    aws_eks_addon.ebs-csi,
+    module.efs_csi_irsa_role,
+    module.ebs_csi_irsa_role,
+    null_resource.eks_post_deployment_actions
   ]
 }
 

--- a/dev_env/jupyterhub/jupyter_helm.tf
+++ b/dev_env/jupyterhub/jupyter_helm.tf
@@ -35,6 +35,8 @@ resource "helm_release" "jupyter_helm" {
     aws_eks_addon.ebs-csi,
     module.efs_csi_irsa_role,
     module.ebs_csi_irsa_role,
+    kubernetes_persistent_volume.dev_support_shared_volume,
+    kubernetes_persistent_volume_claim.dev_support_shared_volume_claim,
     null_resource.eks_post_deployment_actions
   ]
 }

--- a/dev_env/jupyterhub/modules/load_balancer/main.tf
+++ b/dev_env/jupyterhub/modules/load_balancer/main.tf
@@ -2,19 +2,19 @@
 # Application Load Balancer connecting to the EKS cluster
 
 resource "aws_lb" "jupyter_alb" {
-  name               = "jupyter-${var.venue_prefix}${var.venue}-alb"
+  name               = "jupyter-${var.deployment_name}-${var.venue}-alb"
   load_balancer_type = "application"
   security_groups    = [ var.security_group_id ]
   internal           = var.internal
   subnets            = var.lb_subnet_ids
 
   tags = {
-    Name = "${var.resource_prefix}-${var.venue_prefix}${var.venue}-jupyter-alb"
+    Name = "${var.resource_prefix}-${var.deployment_name}-${var.venue}-jupyter-alb"
   }
 }
 
 resource "aws_lb_target_group" "jupyter_alb_target_group" {
-  name        = "jupyter-${var.venue_prefix}${var.venue}-alb-tg"
+  name        = "jupyter-${var.deployment_name}-${var.venue}-alb-tg"
   target_type = "instance"
   vpc_id      = var.vpc_id
 
@@ -22,7 +22,7 @@ resource "aws_lb_target_group" "jupyter_alb_target_group" {
   port             = var.jupyter_proxy_port
 
   tags = {
-    name = "${var.resource_prefix}-${var.venue_prefix}${var.venue}-alb-target-group"
+    name = "${var.resource_prefix}-${var.deployment_name}-${var.venue}-alb-target-group"
   }
 
   # alter the destination of the health check
@@ -39,7 +39,7 @@ resource "aws_lb_listener" "jupyter_alb_listener" {
   protocol          = "HTTP"
 
   tags = {
-    Name = "${var.resource_prefix}-${var.venue_prefix}${var.venue}-alb-listener"
+    Name = "${var.resource_prefix}-${var.deployment_name}-${var.venue}-alb-listener"
   }
 
   default_action {

--- a/dev_env/jupyterhub/modules/load_balancer/variables.tf
+++ b/dev_env/jupyterhub/modules/load_balancer/variables.tf
@@ -12,7 +12,7 @@ variable "venue" {
   type        = string
 }
 
-variable "venue_prefix" {
+variable "deployment_name" {
   description = "Optional string to place before the venue name in resource names"
   type        = string
 }

--- a/dev_env/jupyterhub/s3_access.tf
+++ b/dev_env/jupyterhub/s3_access.tf
@@ -36,7 +36,7 @@ locals {
 }
 
 resource "aws_iam_policy" "s3_access_policy" {
-  name = "Unity-ADS-${var.venue_prefix}${var.venue}-JupyterS3Policy"
+  name = "Unity-ADS-${var.deployment_name}-${var.venue}-JupyterS3Policy"
 
   # If no s3 buckets are defined in the variable supply a dummy policy
   policy = length(var.jupyter_s3_buckets) > 0 ?  local.s3_buckets_policy : local.empty_policy
@@ -45,7 +45,7 @@ resource "aws_iam_policy" "s3_access_policy" {
 module "s3_irsa_role" {
   source = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
 
-  role_name             = "Unity-ADS-${var.venue_prefix}${var.venue}-S3ServiceAccount"
+  role_name             = "Unity-ADS-${var.deployment_name}-${var.venue}-S3ServiceAccount"
 
   role_policy_arns = {
     policy = aws_iam_policy.s3_access_policy.arn

--- a/dev_env/jupyterhub/security_group.tf
+++ b/dev_env/jupyterhub/security_group.tf
@@ -1,11 +1,11 @@
 resource "aws_security_group" "jupyter_lb_sg" {
-  name        = "${var.resource_prefix}-${var.venue_prefix}${var.venue}-lb-sg"
-  description = "U-ADS ${var.venue_prefix}${var.venue} JupyterHub application load balancer security group"
+  name        = "${var.resource_prefix}-${var.deployment_name}-${var.venue}-lb-sg"
+  description = "U-ADS ${var.deployment_name}-${var.venue} JupyterHub application load balancer security group"
 
   vpc_id = data.aws_ssm_parameter.vpc_id.value
 
   tags = {
-    Name = "${var.resource_prefix}-${var.venue_prefix}${var.venue}-lb-sg"
+    Name = "${var.resource_prefix}-${var.deployment_name}-${var.venue}-lb-sg"
   }
 
   # Allow all outbound traffic.

--- a/dev_env/jupyterhub/shared_resources.tf
+++ b/dev_env/jupyterhub/shared_resources.tf
@@ -1,1 +1,19 @@
-../common/shared_resources.tf
+data "aws_efs_file_system" "dev_support_fs" {
+  tags = {
+    Name = "${var.efs_identifier}"
+  }
+}
+
+# Extract out access point id that has the /shared root directory path
+data "aws_efs_access_points" "fs_access_point_ids" {
+  file_system_id = data.aws_efs_file_system.dev_support_fs.id
+}
+
+data "aws_efs_access_point" "fs_access_point_info" {
+  for_each = toset(data.aws_efs_access_points.fs_access_point_ids.ids)
+  access_point_id = each.value
+}
+
+locals {
+  dev_support_shared_ap_id = [ for ap in data.aws_efs_access_point.fs_access_point_info : ap.id if ap.root_directory[0].path == "/shared" ][0]
+}

--- a/dev_env/jupyterhub/versions.tf
+++ b/dev_env/jupyterhub/versions.tf
@@ -1,1 +1,9 @@
-../../common/versions.tf
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.0.0"
+    }
+  }
+  required_version = ">= 0.14"
+}

--- a/dev_env/jupyterhub/versions.tf
+++ b/dev_env/jupyterhub/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">=5.75.0"
+      version = ">= 5.0.0"
     }
   }
 }

--- a/dev_env/jupyterhub/versions.tf
+++ b/dev_env/jupyterhub/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.0.0"
+      version = ">= 5.48.0"
     }
   }
 }

--- a/dev_env/jupyterhub/versions.tf
+++ b/dev_env/jupyterhub/versions.tf
@@ -1,9 +1,9 @@
 terraform {
+  required_version = "~> 1.8.2"
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.0.0"
+      version = "5.47.0"
     }
   }
-  required_version = ">= 0.14"
 }

--- a/dev_env/jupyterhub/versions.tf
+++ b/dev_env/jupyterhub/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">=5.47.0"
+      version = ">=5.75.0"
     }
   }
 }

--- a/dev_env/jupyterhub/versions.tf
+++ b/dev_env/jupyterhub/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "5.47.0"
+      version = ">=5.47.0"
     }
   }
 }

--- a/dev_env/jupyterhub/versions.tf
+++ b/dev_env/jupyterhub/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.48.0"
+      version = ">= 5.47.0"
     }
   }
 }

--- a/dev_env/jupyterhub/versions.tf
+++ b/dev_env/jupyterhub/versions.tf
@@ -1,5 +1,4 @@
 terraform {
-  required_version = "~> 1.8.2"
   required_providers {
     aws = {
       source  = "hashicorp/aws"

--- a/dev_env/shared_storage/aws.tf
+++ b/dev_env/shared_storage/aws.tf
@@ -1,1 +1,17 @@
-../../common/aws.tf
+locals {
+  cost_tags = {
+    ServiceArea = "аds"
+    Proj = "${var.project}"
+    Venue = "${var.deployment_name}-${var.venue}"
+    Component = "${var.component_cost_name}"
+    CreatedBy = "ads"
+    Env = "${var.resource_prefix}"
+    Stack = "${var.component_cost_name}"
+  }
+}
+
+provider "aws" {
+  default_tags {
+    tags = local.cost_tags
+  }
+}

--- a/dev_env/shared_storage/aws.tf
+++ b/dev_env/shared_storage/aws.tf
@@ -9,9 +9,3 @@ locals {
     Stack = "${var.component_cost_name}"
   }
 }
-
-provider "aws" {
-  default_tags {
-    tags = local.cost_tags
-  }
-}

--- a/dev_env/shared_storage/common_variables.tf
+++ b/dev_env/shared_storage/common_variables.tf
@@ -1,1 +1,0 @@
-../../common/variables.tf

--- a/dev_env/shared_storage/efs.tf
+++ b/dev_env/shared_storage/efs.tf
@@ -1,20 +1,20 @@
 resource "aws_kms_key" "efs_key" {
-  description             = "KMS key for Jupyter ${var.venue_prefix}${var.venue} EFS encryption"
+  description             = "KMS key for Jupyter ${var.deployment_name}-${var.venue} EFS encryption"
   deletion_window_in_days = 7
   enable_key_rotation     = true
 
   tags = {
-    Name = "${var.resource_prefix}-EfsKmsKey-${var.venue_prefix}${var.venue}"
+    Name = "${var.resource_prefix}-EfsKmsKey-${var.deployment_name}-${var.venue}"
   }
 }
 
 resource "aws_kms_alias" "efs_key_alias" {
-  name          = "alias/${var.resource_prefix}-${var.venue_prefix}${var.venue}-efs-key"
+  name          = "alias/${var.resource_prefix}-${var.deployment_name}-${var.venue}-efs-key"
   target_key_id = aws_kms_key.efs_key.key_id
 }
 
 resource "aws_efs_file_system" "dev_support_efs" {
-   creation_token   = "${var.resource_prefix}-${var.venue_prefix}${var.venue}-efs-token"
+   creation_token   = "${var.resource_prefix}-${var.deployment_name}-${var.venue}-efs-token"
    performance_mode = "generalPurpose"
    encrypted        = true
    kms_key_id       = aws_kms_key.efs_key.arn

--- a/dev_env/shared_storage/variables.tf
+++ b/dev_env/shared_storage/variables.tf
@@ -1,0 +1,28 @@
+variable "project" {
+  description = "The name of the project matching the /unity/<{project>/<venue</project-name SSM parameter"
+  type        = string
+  default     = "unity"
+}
+
+variable "venue" {
+  description = "The name of the unity venue matching the /unity/<project>/<venue>/venue-name SSM parameter"
+  type        = string
+}
+
+variable "deployment_name" {
+  description = "Optional string to place before the venue name in resource names"
+  type        = string
+  default     = ""
+}
+
+variable "resource_prefix" {
+  description = "String used at the beginning of the names for all resources to identify them according to the UADS subsystem"
+  type        = string
+  default     = "uads"
+}
+
+variable "efs_identifier" {
+  description = "EFS file system to connect Jupyter shared storage with"
+  type        = string
+  # Example value:uads-development-efs-fs"
+}

--- a/dev_env/shared_storage/variables.tf
+++ b/dev_env/shared_storage/variables.tf
@@ -26,3 +26,13 @@ variable "efs_identifier" {
   type        = string
   # Example value:uads-development-efs-fs"
 }
+
+variable "installprefix" {
+  description = "Installation prefix"
+  type        = string
+  default     = ""
+}
+
+variable "tags" {
+  type = map(string)
+}

--- a/dev_env/shared_storage/versions.tf
+++ b/dev_env/shared_storage/versions.tf
@@ -1,1 +1,9 @@
-../../common/versions.tf
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.0.0"
+    }
+  }
+  required_version = ">= 0.14"
+}

--- a/dev_env/shared_storage/versions.tf
+++ b/dev_env/shared_storage/versions.tf
@@ -1,9 +1,9 @@
 terraform {
+  required_version = "~> 1.8.2"
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.0.0"
+      version = "5.47.0"
     }
   }
-  required_version = ">= 0.14"
 }

--- a/dev_env/shared_storage/versions.tf
+++ b/dev_env/shared_storage/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.48.0"
+      version = ">= 5.47.0"
     }
   }
 }

--- a/dev_env/shared_storage/versions.tf
+++ b/dev_env/shared_storage/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "5.47.0"
+      version = ">= 5.48.0"
     }
   }
 }

--- a/dev_env/vars_jupyter.example.sh
+++ b/dev_env/vars_jupyter.example.sh
@@ -5,7 +5,7 @@ export KUBE_CONFIG_PATH=$HOME/.kube/config
 # Required to be set before beginning installation
 export TF_VAR_project="unity"
 export TF_VAR_venue="dev"
-export TF_VAR_venue_prefix="venue-"
+export TF_VAR_deployment_name="venue"
 
 export TF_VAR_efs_identifier="uads-venue-dev-efs-fs"
 


### PR DESCRIPTION
## Purpose
This PR updates unity-ads-deployment to support EFS and JupyterHub deployment from the Unity Management Console via the Marketplace while maintaining deployment capability without the MC/Marketplace (e.g. running terraform from laptop).

## Proposed Changes
- [CHANGE] refactored to support MC-injected variables
  - removed symlinking of files that were shared between EFS and Jupyterhub terraform directories to allow for independent deployment via Marketplace
- [CHANGE] add explicit dependencies to aid in ordering the destruction of AWS resources during `terraform destroy`
- [FIX] support deployment without the MC/Marketplace
 
## Issues
- [Integrate U-ADS into marketplace#3](https://github.com/unity-sds/unity-ads/issues/3)
- [JupyterHub integration into Unity Marketplace#90](https://github.com/unity-sds/unity-project-management/issues/90)
- [JupyterHub Integration into Unity Marketplace: Create Marketplace JSON#491](https://github.com/unity-sds/unity-cs/issues/491)
- [JupyterHub Integration into Unity Marketplace: Refactor IAC code for marketplace deployments#490](https://github.com/unity-sds/unity-cs/issues/490)
- 
## Testing
- See video of live demo showing deployment of EFS and Jupyterhub from the MC/Marketplace (QSR slides)
- Manually ran terraform on laptop to deploy EFS and Jupyterhub to ensure they can be deployed without the MC/Marketplace
