### PR TITLE
Allow an empty deployment name without inserting an extra hypen

### DIFF
--- a/dev_env/jupyterhub/aws.tf
+++ b/dev_env/jupyterhub/aws.tf
@@ -2,7 +2,7 @@ locals {
   cost_tags = {
     ServiceArea = "аds"
     Proj = "${var.project}"
-    Venue = "${var.deployment_name}-${var.venue}"
+    Venue = "${local.deployment_name}${var.venue}"
     Component = "${var.component_cost_name}"
     CreatedBy = "ads"
     Env = "${var.resource_prefix}"

--- a/dev_env/jupyterhub/common_variables.tf
+++ b/dev_env/jupyterhub/common_variables.tf
@@ -36,3 +36,9 @@ variable "installprefix" {
 variable "tags" {
   type = map(string)
 }
+
+locals {
+  # Use this instead of deployment name
+  # It prevents including an extra hypen when deployment_name is not defined
+  deployment_name = var.deployment_name != "" ? "${var.deployment_name}-" : ""
+}

--- a/dev_env/jupyterhub/efs.tf
+++ b/dev_env/jupyterhub/efs.tf
@@ -1,5 +1,5 @@
 resource "aws_security_group" "dev_support_efs_jupyter_sg" {
-   name = "${var.resource_prefix}-${var.deployment_name}-${var.venue}-efs-jupyter-sg"
+   name = "${var.resource_prefix}-${local.deployment_name}${var.venue}-efs-jupyter-sg"
    description= "Allows inbound EFS traffic from Jupyter cluster"
    vpc_id = data.aws_ssm_parameter.vpc_id.value
 
@@ -54,7 +54,7 @@ resource "kubernetes_storage_class" "efs_storage_class" {
 # https://kubernetes.io/docs/concepts/storage/persistent-volumes/
 resource "kubernetes_persistent_volume" "dev_support_shared_volume" {
   metadata {
-    name = "${var.resource_prefix}-${var.deployment_name}-${var.venue}-dev-data"
+    name = "${var.resource_prefix}-${local.deployment_name}${var.venue}-dev-data"
   }
 
   spec {
@@ -89,7 +89,7 @@ resource "kubernetes_persistent_volume" "dev_support_shared_volume" {
 
 resource "kubernetes_persistent_volume_claim" "dev_support_shared_volume_claim" {
   metadata {
-    name = "${var.resource_prefix}-${var.deployment_name}-${var.venue}-dev-data"
+    name = "${var.resource_prefix}-${local.deployment_name}${var.venue}-dev-data"
     namespace = helm_release.jupyter_helm.namespace
   }
 

--- a/dev_env/jupyterhub/eks_cluster.tf
+++ b/dev_env/jupyterhub/eks_cluster.tf
@@ -13,13 +13,13 @@ data "external" "current_ip" {
 }
 
 resource "aws_security_group" "mc_instance_k8s_api_access" {
-  name        = "${var.resource_prefix}-${var.deployment_name}-${var.venue}-mc-sg"
+  name        = "${var.resource_prefix}-${local.deployment_name}${var.venue}-mc-sg"
   description = "Security group to allow access to K8s API from MC instance"
 
   vpc_id = data.aws_ssm_parameter.vpc_id.value
 
   tags = {
-    Name = "${var.resource_prefix}-${var.deployment_name}-${var.venue}-mc-sg"
+    Name = "${var.resource_prefix}-${local.deployment_name}${var.venue}-mc-sg"
   }
 
   # Allow all outbound traffic.
@@ -45,7 +45,7 @@ module "eks" {
   # pin to 20.16.0 because unity-proxy is pinned to hashicorp/aws 5.47.0
   version = "20.16.0"
 
-  cluster_name    = "${var.resource_prefix}-${var.deployment_name}-${var.venue}-jupyter"
+  cluster_name    = "${var.resource_prefix}-${local.deployment_name}${var.venue}-jupyter"
   cluster_version = "1.30"
 
   cluster_addons = {
@@ -67,7 +67,7 @@ module "eks" {
   enable_irsa = true
 
   create_iam_role = true
-  iam_role_name = "Unity-ADS-${var.deployment_name}-${var.venue}-EKSClusterRole"
+  iam_role_name = "Unity-ADS-${local.deployment_name}${var.venue}-EKSClusterRole"
   iam_role_permissions_boundary = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:policy/mcp-tenantOperator-AMI-APIG"
 
   cluster_endpoint_public_access = true
@@ -79,7 +79,7 @@ module "eks" {
 
   eks_managed_node_group_defaults = {
     create_iam_role = true
-    iam_role_name = "Unity-ADS-${var.deployment_name}-${var.venue}-EKSNodeRole"
+    iam_role_name = "Unity-ADS-${local.deployment_name}${var.venue}-EKSNodeRole"
     iam_role_permissions_boundary = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:policy/mcp-tenantOperator-AMI-APIG"
 
     ami_id          = data.aws_ssm_parameter.ami_id.value

--- a/dev_env/jupyterhub/frontend.tf
+++ b/dev_env/jupyterhub/frontend.tf
@@ -36,7 +36,7 @@ module "frontend" {
 
   project = var.project
   venue = var.venue
-  deployment_name = var.deployment_name
+  deployment_name = local.deployment_name
   resource_prefix = var.resource_prefix
   load_balancer_port = local.load_balancer_port
   jupyter_proxy_port = var.jupyter_proxy_port

--- a/dev_env/jupyterhub/jupyter_helm.tf
+++ b/dev_env/jupyterhub/jupyter_helm.tf
@@ -2,7 +2,7 @@ resource "helm_release" "jupyter_helm" {
   name       = "jupyterhub"
   repository = "https://jupyterhub.github.io/helm-chart"
   chart      = "jupyterhub"
-  namespace  = "jhub-${var.deployment_name}-${var.venue}"
+  namespace  = "jhub-${local.deployment_name}${var.venue}"
   version    = "3.1.0"
   timeout    = 3600
 

--- a/dev_env/jupyterhub/modules/load_balancer/main.tf
+++ b/dev_env/jupyterhub/modules/load_balancer/main.tf
@@ -2,19 +2,19 @@
 # Application Load Balancer connecting to the EKS cluster
 
 resource "aws_lb" "jupyter_alb" {
-  name               = "jupyter-${var.deployment_name}-${var.venue}-alb"
+  name               = "jupyter-${var.deployment_name}${var.venue}-alb"
   load_balancer_type = "application"
   security_groups    = [ var.security_group_id ]
   internal           = var.internal
   subnets            = var.lb_subnet_ids
 
   tags = {
-    Name = "${var.resource_prefix}-${var.deployment_name}-${var.venue}-jupyter-alb"
+    Name = "${var.resource_prefix}-${var.deployment_name}${var.venue}-jupyter-alb"
   }
 }
 
 resource "aws_lb_target_group" "jupyter_alb_target_group" {
-  name        = "jupyter-${var.deployment_name}-${var.venue}-alb-tg"
+  name        = "jupyter-${var.deployment_name}${var.venue}-alb-tg"
   target_type = "instance"
   vpc_id      = var.vpc_id
 
@@ -22,7 +22,7 @@ resource "aws_lb_target_group" "jupyter_alb_target_group" {
   port             = var.jupyter_proxy_port
 
   tags = {
-    name = "${var.resource_prefix}-${var.deployment_name}-${var.venue}-alb-target-group"
+    name = "${var.resource_prefix}-${var.deployment_name}${var.venue}-alb-target-group"
   }
 
   # alter the destination of the health check
@@ -39,7 +39,7 @@ resource "aws_lb_listener" "jupyter_alb_listener" {
   protocol          = "HTTP"
 
   tags = {
-    Name = "${var.resource_prefix}-${var.deployment_name}-${var.venue}-alb-listener"
+    Name = "${var.resource_prefix}-${var.deployment_name}${var.venue}-alb-listener"
   }
 
   default_action {

--- a/dev_env/jupyterhub/s3_access.tf
+++ b/dev_env/jupyterhub/s3_access.tf
@@ -36,7 +36,7 @@ locals {
 }
 
 resource "aws_iam_policy" "s3_access_policy" {
-  name = "Unity-ADS-${var.deployment_name}-${var.venue}-JupyterS3Policy"
+  name = "Unity-ADS-${local.deployment_name}${var.venue}-JupyterS3Policy"
 
   # If no s3 buckets are defined in the variable supply a dummy policy
   policy = length(var.jupyter_s3_buckets) > 0 ?  local.s3_buckets_policy : local.empty_policy
@@ -45,7 +45,7 @@ resource "aws_iam_policy" "s3_access_policy" {
 module "s3_irsa_role" {
   source = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
 
-  role_name             = "Unity-ADS-${var.deployment_name}-${var.venue}-S3ServiceAccount"
+  role_name             = "Unity-ADS-${local.deployment_name}${var.venue}-S3ServiceAccount"
 
   role_policy_arns = {
     policy = aws_iam_policy.s3_access_policy.arn

--- a/dev_env/jupyterhub/security_group.tf
+++ b/dev_env/jupyterhub/security_group.tf
@@ -1,11 +1,11 @@
 resource "aws_security_group" "jupyter_lb_sg" {
-  name        = "${var.resource_prefix}-${var.deployment_name}-${var.venue}-lb-sg"
-  description = "U-ADS ${var.deployment_name}-${var.venue} JupyterHub application load balancer security group"
+  name        = "${var.resource_prefix}-${local.deployment_name}${var.venue}-lb-sg"
+  description = "U-ADS ${local.deployment_name}${var.venue} JupyterHub application load balancer security group"
 
   vpc_id = data.aws_ssm_parameter.vpc_id.value
 
   tags = {
-    Name = "${var.resource_prefix}-${var.deployment_name}-${var.venue}-lb-sg"
+    Name = "${var.resource_prefix}-${local.deployment_name}${var.venue}-lb-sg"
   }
 
   # Allow all outbound traffic.


### PR DESCRIPTION
Allow an empty deployment name without inserting an extra hypen in the name of all the various resources.